### PR TITLE
Add specific cases for JS Template Literals

### DIFF
--- a/themes/Monokai++.tmTheme
+++ b/themes/Monokai++.tmTheme
@@ -483,6 +483,35 @@
 			</dict>
 		</dict>
 
+		<!-- JS Template Literals -->
+		<dict>
+			<key>name</key>
+			<string>JS template string literal delimiters</string>
+			<key>scope</key>
+			<string>string.template-string punctuation.template-string.element.begin, punctuation.template-string.element.end</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>normal</string>
+				<key>foreground</key>
+				<string>#fd9720</string>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>name</key>
+			<string>JS template string literal object props</string>
+			<key>scope</key>
+			<string>string.template-string meta.property.object</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>normal</string>
+				<key>foreground</key>
+				<string>#cccccc</string>
+			</dict>
+		</dict>
+
 		<!-- diff -->
 		<dict>
 			<key>name</key>


### PR DESCRIPTION
Mark being / end of placeholders, and make regular property access within the placeholders show as 'normal' not string.

Note I'm not 100% certain the 'fix' for property access is correct. In this line of code:

    const test1 = `${var1.prop}/something/${var2.calc('test')}/else`

the `.prop` in `var1.prop` shows in yellow rather than white. The scope from JS Next is `source.js string.template-string.js entity.template-string.element.js meta.property.object.js` but it feels like this should be done elsewhere. However, with this fix, I get this which looks good to me:

![image](https://user-images.githubusercontent.com/900542/73347403-6fab5280-427f-11ea-8153-7245ff403d4c.png)
