### PR TITLE
Differentiate html tags from attributes

### DIFF
--- a/themes/Monokai++.tmTheme
+++ b/themes/Monokai++.tmTheme
@@ -242,7 +242,7 @@
 			<key>name</key>
 			<string>Member variables</string>
 			<key>scope</key>
-			<string>variable.language, variable.other.member, variable.parameter, variable.other.readwrite.member</string>
+			<string>variable.language, variable.other.member, variable.parameter, variable.other.readwrite.member, entity.other.attribute-name</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -283,18 +283,6 @@
 			<dict>
 				<key>foreground</key>
 				<string>#f92672</string>
-			</dict>
-		</dict>
-
-		<dict>
-			<key>name</key>
-			<string>Tags</string>
-			<key>scope</key>
-			<string>entity.other.attribute-name</string>
-			<key>settings</key>
-			<dict>
-				<key>foreground</key>
-				<string>#fd971f</string>
 			</dict>
 		</dict>
 

--- a/themes/Monokai++.tmTheme
+++ b/themes/Monokai++.tmTheme
@@ -278,11 +278,23 @@
 			<key>name</key>
 			<string>Tags</string>
 			<key>scope</key>
-			<string>entity.name.tag, entity.other.attribute-name</string>
+			<string>entity.name.tag</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
 				<string>#f92672</string>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>name</key>
+			<string>Tags</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#fd971f</string>
 			</dict>
 		</dict>
 


### PR DESCRIPTION
I do a lot of work in Vue, and so obviously have extensive use of attributes. Visually separating them as 'properties' of the tags makes things much clearer to me, but I realise this might not be to everyone's taste.